### PR TITLE
Explicitly set DEFAULT_AUTO_FIELD in project settings

### DIFF
--- a/todoApp/settings.py
+++ b/todoApp/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Explicitly set DEFAULT_AUTO_FIELD to AutoField because your model uses auto-created primary keys. Starting with Django 3.2 you should have this setting set if using implicit primary key in app models.