### PR TITLE
Update settings.py

### DIFF
--- a/todoApp/settings.py
+++ b/todoApp/settings.py
@@ -81,7 +81,7 @@ DATABASES = {
     }
 }
 
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 

--- a/todoApp/settings.py
+++ b/todoApp/settings.py
@@ -81,7 +81,7 @@ DATABASES = {
     }
 }
 
-
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
Explicitly set DEFAULT_AUTO_FIELD to AutoField because your model uses auto-created primary keys. Starting with Django 3.2 you should have this setting set if using implicit primary key in app models